### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/resistor-color-trio/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Futhark specific notes
 
 Any spaces should appear to the left of the value, or to the right of the unit:

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For this exercise, returning the list of colors is not required.

--- a/exercises/practice/transpose/.docs/instructions.append.md
+++ b/exercises/practice/transpose/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 **Note:** In Futhark, multi-dimensional arrays are always regular: inner arrays all have the same length.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.